### PR TITLE
Render damage/heal/status indicators on tile instead of entity sprite

### DIFF
--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -43,6 +43,22 @@ export const Tile: FC<{
     }
   }, [entityIfExist]);
 
+  const entityTileID = useMemo(() => {
+    let idString = 'tile_';
+
+    if (entityIfExist) {
+      if (entityIfExist[0] === ENTITY_TYPE.PLAYER) {
+        idString += 'player_';
+      } else if (entityIfExist[0] === ENTITY_TYPE.ENEMY) {
+        idString += 'enemy_';
+      }
+
+      idString += entityIfExist[1];
+    }
+
+    return idString;
+  }, [entityIfExist]);
+
   const isAttackEffectTile = useMemo(() => {
     return (
       tileType !== TILE_TYPE.WALL && tileType !== TILE_TYPE.DOOR && !hasPlayer
@@ -186,6 +202,7 @@ export const Tile: FC<{
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      id={entityTileID}
     >
       <div
         style={{

--- a/src/skill_utils.tsx
+++ b/src/skill_utils.tsx
@@ -220,7 +220,7 @@ const handleSkillDamage = (
       newEnemy.health = damageEntity(
         newEnemy,
         totalDamage,
-        `${newEnemy.entityType}_${newEnemy.id}`
+        `tile_${newEnemy.entityType}_${newEnemy.id}`
       );
       // newEnemy.health = newEnemy.health - totalDamage;
 
@@ -242,7 +242,7 @@ const handleSkillDamage = (
         playerAfterDamage.health = healEntity(
           playerAfterDamage,
           lifestealAmount,
-          `${player.entityType}_${player.id}`
+          `tile_${player.entityType}_${player.id}`
         );
       }
 
@@ -329,7 +329,7 @@ const handleSkillDamage = (
       playerAfterDamage.health = damageEntity(
         playerAfterDamage,
         totalDamageToPlayer,
-        `${playerAfterDamage.entityType}_${playerAfterDamage.id}`
+        `tile_${playerAfterDamage.entityType}_${playerAfterDamage.id}`
       );
       // playerAfterDamage.health = playerAfterDamage.health - totalDamageToPlayer;
 
@@ -453,7 +453,7 @@ const handleSkillStatus = (
     displayStatusEffect(
       statusToBeApplied,
       true,
-      `${playerAfterStatus.entityType}_${playerAfterStatus.id}`
+      `tile_${playerAfterStatus.entityType}_${playerAfterStatus.id}`
     );
 
     return { playerAfterStatus, enemiesAfterStatus };
@@ -505,7 +505,7 @@ const handleSkillStatus = (
         displayStatusEffect(
           statusToBeApplied,
           true,
-          `${newEnemy.entityType}_${newEnemy.id}`
+          `tile_${newEnemy.entityType}_${newEnemy.id}`
         );
 
         enemiesAfterStatus[enemyIndex] = newEnemy;
@@ -537,7 +537,7 @@ const handleSkillStatus = (
         displayStatusEffect(
           statusToBeApplied,
           true,
-          `${playerAfterStatus.entityType}_${playerAfterStatus.id}`
+          `tile_${playerAfterStatus.entityType}_${playerAfterStatus.id}`
         );
       }
     }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -406,27 +406,20 @@ export const getPlayerMaxHealth = (player: IPlayer) => {
 export const damageEntity = (
   entity: IPlayer | IEnemy,
   damage: number,
-  entitySpriteID: string
+  elementID: string
 ) => {
-  // console.log('damageEntity', entity, damage, entitySpriteID);
+  // console.log('damageEntity', entity, damage, elementID);
   const newHealth = entity.health - damage;
 
   // Display damage numbers
-  displayDamageNumbers(entitySpriteID, damage);
+  displayDamageNumbers(elementID, damage);
 
   return newHealth;
 };
 
-const displayDamageNumbers = (entitySpriteID: string, damage: number) => {
-  // Find sprite position
-  const sprite = document.querySelector(`#${entitySpriteID}`);
-
-  if (!sprite) {
-    console.error('displayDamageNumbers: Sprite not found');
-    return;
-  }
-
-  const tile = sprite.parentElement?.parentElement;
+const displayDamageNumbers = (elementID: string, damage: number) => {
+  // Find tile position of sprite
+  const tile = document.querySelector(`#${elementID}`);
 
   if (!tile) {
     console.error('displayDamageNumbers: Tile not found');
@@ -460,30 +453,23 @@ const displayDamageNumbers = (entitySpriteID: string, damage: number) => {
 export const healEntity = (
   entity: IPlayer | IEnemy,
   healAmount: number,
-  entitySpriteID: string
+  elementID: string
 ) => {
-  // console.log('damageEntity', entity, heal, entitySpriteID);
+  // console.log('damageEntity', entity, heal, elementID);
   const newHealth = entity.health + healAmount;
 
   // Display heal numbers
-  displayHealNumbers(entitySpriteID, healAmount);
+  displayHealNumbers(elementID, healAmount);
 
   return newHealth;
 };
 
-const displayHealNumbers = (entitySpriteID: string, heal: number) => {
-  // Find sprite position
-  const sprite = document.querySelector(`#${entitySpriteID}`);
-
-  if (!sprite) {
-    console.error('displayDamageNumbers: Sprite not found');
-    return;
-  }
-
-  const tile = sprite.parentElement?.parentElement;
+const displayHealNumbers = (elementID: string, heal: number) => {
+  // Find tile position of sprite
+  const tile = document.querySelector(`#${elementID}`);
 
   if (!tile) {
-    console.error('displayDamageNumbers: Tile not found');
+    console.error('displayHealNumbers: Tile not found');
     return;
   }
 
@@ -514,17 +500,10 @@ const displayHealNumbers = (entitySpriteID: string, heal: number) => {
 export const displayStatusEffect = (
   status: IStatus,
   gain: boolean,
-  entitySpriteID: string
+  elementID: string
 ) => {
-  // Find sprite position
-  const sprite = document.querySelector(`#${entitySpriteID}`);
-
-  if (!sprite) {
-    console.error('displayStatusEffect: Sprite not found');
-    return;
-  }
-
-  const tile = sprite.parentElement?.parentElement;
+  // Find tile position of sprite
+  const tile = document.querySelector(`#${elementID}`);
 
   if (!tile) {
     console.error('displayStatusEffect: Tile not found');


### PR DESCRIPTION
Implementing the indicators on tiles instead of entity sprites avoid the indicators to disappear or appear to not show when entity dies immediately after an attack.