### PR TITLE
Fix indicator display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -401,7 +401,10 @@ function App() {
                   height: roomLength * TILE_SIZE,
                 }}
               >
-                <div className="absolute top-0 left-0 z-20">
+                <div
+                  id="entity_sprite_positions"
+                  className="absolute top-0 left-0 z-20"
+                >
                   <EntitySpritePositions
                     setCurrentHoveredEntity={setCurrentHoveredEntity}
                   />

--- a/src/components/EntitySpritePositions.tsx
+++ b/src/components/EntitySpritePositions.tsx
@@ -152,7 +152,7 @@ export const EntitySpritePositions: FC<{
   };
 
   return (
-    <div>
+    <>
       {roomEntityPositionsFlipped.map((entityPosition) => {
         // console.log(positionString, entityType, entityID);
 
@@ -192,7 +192,7 @@ export const EntitySpritePositions: FC<{
           );
         }
       })}
-    </div>
+    </>
   );
 };
 

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -339,7 +339,7 @@ export const Room: FC<{
 
               setTimeout(() => {
                 setEnemies(enemies.filter((e) => e.id !== affectedEnemy.id));
-              }, 1000);
+              }, 1200);
             } else {
               addLog({
                 message: (
@@ -1054,6 +1054,7 @@ export const Room: FC<{
 
   return (
     <div
+      id="room"
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${roomLength}, ${TILE_SIZE}px)`,

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,18 @@ p {
   font-size: 1.15em;
 }
 
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+  text-shadow:
+    1px 0 0 #000,
+    0 -1px 0 #000,
+    0 1px 0 #000,
+    -1px 0 0 #000;
+}
+
 button {
   /* border-radius: 8px; */
   border: 1px solid transparent;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -228,7 +228,11 @@ export const handlePlayerEndTurn = (
     // Filter out the new statuses with duration 0
     const filteredStatuses = newStatuses.filter((status) => {
       if (status.durationCounter <= 0) {
-        displayStatusEffect(status, false, `${player.entityType}_${player.id}`);
+        displayStatusEffect(
+          status,
+          false,
+          `tile_${player.entityType}_${player.id}`
+        );
         return false;
       }
       return true;
@@ -687,12 +691,26 @@ export const damageEntity = (
 
 const displayDamageNumbers = (elementID: string, damage: number) => {
   // Find tile position of sprite
-  const tile = document.querySelector(`#${elementID}`);
+  const tile = document.getElementById(`${elementID}`);
+
+  // Find room element
+  const entitySpritePositions = document.getElementById(
+    'entity_sprite_positions'
+  );
 
   if (!tile) {
-    console.error('displayDamageNumbers: Tile not found');
+    console.error('displayStatusEffect: Tile not found');
     return;
   }
+
+  if (!entitySpritePositions) {
+    console.error('displayStatusEffect: entitySpritePositions not found');
+    return;
+  }
+
+  // Get position of tile relative to the parent element
+  const tileLeftPosition = tile.offsetLeft;
+  const tileTopPosition = tile.offsetTop;
 
   // Display damage numbers
   const damageNumbers = document.createElement('h1');
@@ -702,11 +720,11 @@ const displayDamageNumbers = (elementID: string, damage: number) => {
   damageNumbers.style.fontWeight = 'bold';
   damageNumbers.style.fontSize = '1.5rem';
   damageNumbers.style.whiteSpace = 'nowrap';
-  tile.appendChild(damageNumbers);
+  entitySpritePositions.appendChild(damageNumbers);
 
   damageNumbers.style.position = 'absolute';
-  damageNumbers.style.bottom = `${TILE_SIZE * 1.5}px`;
-  damageNumbers.style.left = `${TILE_SIZE / 2 - damageNumbers.offsetWidth / 2}px`;
+  damageNumbers.style.top = `${tileTopPosition - TILE_SIZE * 1.5}px`;
+  damageNumbers.style.left = `${tileLeftPosition + (TILE_SIZE / 2 - damageNumbers.offsetWidth / 2)}px`;
   damageNumbers.style.zIndex = '100';
   damageNumbers.style.color = 'red';
 
@@ -734,12 +752,26 @@ export const healEntity = (
 
 const displayHealNumbers = (elementID: string, heal: number) => {
   // Find tile position of sprite
-  const tile = document.querySelector(`#${elementID}`);
+  const tile = document.getElementById(`${elementID}`);
+
+  // Find room element
+  const entitySpritePositions = document.getElementById(
+    'entity_sprite_positions'
+  );
 
   if (!tile) {
-    console.error('displayHealNumbers: Tile not found');
+    console.error('displayStatusEffect: Tile not found');
     return;
   }
+
+  if (!entitySpritePositions) {
+    console.error('displayStatusEffect: entitySpritePositions not found');
+    return;
+  }
+
+  // Get position of tile relative to the parent element
+  const tileLeftPosition = tile.offsetLeft;
+  const tileTopPosition = tile.offsetTop;
 
   // Display heal numbers
   const healNumbers = document.createElement('h1');
@@ -749,11 +781,11 @@ const displayHealNumbers = (elementID: string, heal: number) => {
   healNumbers.style.fontWeight = 'bold';
   healNumbers.style.fontSize = '1.5rem';
   healNumbers.style.whiteSpace = 'nowrap';
-  tile.appendChild(healNumbers);
+  entitySpritePositions.appendChild(healNumbers);
 
   healNumbers.style.position = 'absolute';
-  healNumbers.style.bottom = `${TILE_SIZE * 1.5}px`;
-  healNumbers.style.left = `${TILE_SIZE / 2 - healNumbers.offsetWidth / 2}px`;
+  healNumbers.style.top = `${tileTopPosition - TILE_SIZE * 1.5}px`;
+  healNumbers.style.left = `${tileLeftPosition + TILE_SIZE / 2 - healNumbers.offsetWidth / 2}px`;
   healNumbers.style.zIndex = '100';
   healNumbers.style.color = 'green';
 
@@ -791,6 +823,15 @@ export const displayStatusEffect = (
   // Get position of tile relative to the parent element
   const tileLeftPosition = tile.offsetLeft;
   const tileTopPosition = tile.offsetTop;
+
+  // console.log(
+  //   'displayStatusEffect',
+  //   status,
+  //   gain,
+  //   elementID,
+  //   tileLeftPosition,
+  //   tileTopPosition
+  // );
 
   // Display status effect
   const statusIndicator = document.createElement('h1');

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -771,12 +771,26 @@ export const displayStatusEffect = (
   elementID: string
 ) => {
   // Find tile position of sprite
-  const tile = document.querySelector(`#${elementID}`);
+  const tile = document.getElementById(`${elementID}`);
+
+  // Find room element
+  const entitySpritePositions = document.getElementById(
+    'entity_sprite_positions'
+  );
 
   if (!tile) {
     console.error('displayStatusEffect: Tile not found');
     return;
   }
+
+  if (!entitySpritePositions) {
+    console.error('displayStatusEffect: entitySpritePositions not found');
+    return;
+  }
+
+  // Get position of tile relative to the parent element
+  const tileLeftPosition = tile.offsetLeft;
+  const tileTopPosition = tile.offsetTop;
 
   // Display status effect
   const statusIndicator = document.createElement('h1');
@@ -786,11 +800,11 @@ export const displayStatusEffect = (
   statusIndicator.style.fontWeight = 'bold';
   statusIndicator.style.fontSize = '1.5rem';
   statusIndicator.style.whiteSpace = 'nowrap';
-  tile.appendChild(statusIndicator);
+  entitySpritePositions.appendChild(statusIndicator);
 
   statusIndicator.style.position = 'absolute';
-  statusIndicator.style.bottom = `${TILE_SIZE}px`;
-  statusIndicator.style.left = `${TILE_SIZE / 2 - statusIndicator.offsetWidth / 2}px`;
+  statusIndicator.style.top = `${tileTopPosition - TILE_SIZE}px`;
+  statusIndicator.style.left = `${tileLeftPosition + (TILE_SIZE / 2 - statusIndicator.offsetWidth / 2)}px`;
   statusIndicator.style.zIndex = '100';
   statusIndicator.style.color = 'yellow';
 


### PR DESCRIPTION
Indicators were children of individual tile/sprite containers so longer status effects get blocked by overflow-hidden property of the container.

Now indicators are children of the room so now longer text in indicators wont be blocked